### PR TITLE
Add Optimizely Page Vars sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build/
-dist/
 node_modules/
 coverage
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This project contains a collection of code samples, integrations, and best pract
 
 ## Using Samples
 
-Samples can be referenced directly from their respective JavaScript files. The `utils` folder contains utility functions that can be used with any integration project or are specific to a vendor. More feature rich use cases exist in the `src` folder in their respective vendor directories. These use cases have a modular design to support testing and composition. To create a sample that can be deployed to your website, see the Building Samples section.
+Compiled samples can be found in the `dist` folder. Each sample is packaged as an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE), which can deployed through a tag manager or simply re-used within your project.
 
 ## Building Samples
 
-To deploy a sample to you website, clone this repo and then do the following:
+If you'd like to modify a sample or build your own, follow these steps:
 
 1. Install [Node.js](https://nodejs.org) as needed.
 2. Change directory to this project's root folder.
 3. Run `npm install`.
-4. Run `npm run build`.
-5. Refer to the files contained in the `dist` folder.
+4. Code your integration as a new JavaScript file in the `src` folder.
+5. Run `npm run build`.
 
-Each sample will be an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). You can deploy the IIFE through a tag manager or simply re-use the code within your own project.
+The `dist` folder will contain a compiled file that has the same name as the one in your `src` folder.

--- a/__mocks__/optimizely.js
+++ b/__mocks__/optimizely.js
@@ -1,0 +1,46 @@
+const campaignsObj = {
+  "19295200540": {
+    "id": "19295200540",
+    "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+    "variation": { "id": "19166174600", "name": "Full Screen " },
+    "isInCampaignHoldback": false,
+  },
+  "20207221285": {
+    "id": "20207221285",
+    "experiment": { "id": "20352536906", "name": "Summer Sale Banner" },
+    "variation": { "id": "20364750429", "name": "Variation #1" },
+    "isInCampaignHoldback": false,
+  },
+  "20380827660": {
+    "id": "20380827660",
+    "experiment": { "id": "20441630527", "name": "Winter Sale Banner" },
+    "variation": { "id": "20336892789", "name": "PUSH" },
+    "isInCampaignHoldback": true,
+  }
+};
+
+Object.defineProperty(window, 'optimizely', {
+  writable: true,
+  value: {
+    get: jest.fn().mockImplementation((api) => {
+      switch (api) {
+        case 'state':
+          return {
+            getCampaignStates: jest.fn().mockImplementation(() => campaignsObj),
+          }
+        case 'utils':
+          return {
+            waitUntil: jest.fn().mockImplementation((callback) => new Promise(function (resolve, reject) {
+              if (callback()) {
+                resolve();
+              } else {
+                reject();
+              }
+            })),
+          }
+        default:
+          throw Error(`optimizely.${api} is not implemented`);
+      }
+    }),
+  },
+});

--- a/__tests__/optimizely-page-vars.spec.js
+++ b/__tests__/optimizely-page-vars.spec.js
@@ -1,0 +1,17 @@
+import '../__mocks__/fs';
+import '../__mocks__/optimizely';
+import '../src/optimizely-page-vars';
+import { fs } from '../src/utils/fs';
+
+describe('Optimizely A/B experiments', () => {
+  test('send experiments as page vars', () => {
+    expect(fs('setVars')).toBeCalled();
+    expect(fs('setVars').mock.calls[0][0]).toEqual('page');
+    expect(fs('setVars').mock.calls[0][1]).toBeDefined();
+
+    const payload = fs('setVars').mock.calls[0][1];
+    expect(payload.optimizely_experiment_names.length).toEqual(2);
+    expect(payload.optimizely_experiment_names).toContain('July 4th Banner=Full Screen');
+    expect(payload.optimizely_experiment_names).toContain('Summer Sale Banner=Variation #1');
+  });
+});

--- a/__tests__/optimizely-utils.spec.js
+++ b/__tests__/optimizely-utils.spec.js
@@ -1,0 +1,67 @@
+import '../__mocks__/optimizely';
+import { campaignsToList, campaignsToPageVars, getActiveCampaigns, getExperimentTuple } from '../src/utils/optimizely';
+
+describe('Optimizely utilities', () => {
+  test('retrieves active campaigns', () => {
+    expect(getActiveCampaigns()).toBeDefined();
+  });
+
+  test('converts campaigns object to list of campaigns', () => {
+    const campaignsObj = getActiveCampaigns();
+    expect(campaignsObj).toBeDefined();
+    expect(campaignsToList(campaignsObj).length).toEqual(3);
+  });
+
+  test('converts campaigns list to FS page vars', () => {
+    const campaignsList = campaignsToList(getActiveCampaigns());
+    expect(campaignsList).toBeDefined();
+    expect(campaignsList.length).toEqual(3);
+
+    const pageVars = campaignsToPageVars(campaignsList);
+    expect(pageVars).toBeDefined();
+    expect(pageVars.optimizely_experiment_ids).toBeDefined();
+    expect(pageVars.optimizely_experiment_ids.length).toEqual(2);
+    expect(pageVars.optimizely_experiment_names).toBeDefined();
+    expect(pageVars.optimizely_experiment_names.length).toEqual(2);
+  });
+
+  test('gets an experiment tuple with experiment and variant names', () => {
+    const experimentAndVariant = getExperimentTuple({
+      "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+      "variation": { "id": "19166174600", "name": "Full Screen " },
+    }, 'name');
+
+    // NOTE that the variant name has been `.trim()`ed
+    expect(experimentAndVariant).toEqual('July 4th Banner=Full Screen');
+
+    const experimentOnly = getExperimentTuple({
+      "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+    }, 'name');
+
+    expect(experimentOnly).toEqual('July 4th Banner');
+  });
+
+  test('gets an experiment tuple with experiment and variant IDs', () => {
+    const experimentAndVariant = getExperimentTuple({
+      "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+      "variation": { "id": "19166174600", "name": "Full Screen " },
+    }, 'id');
+
+    expect(experimentAndVariant).toEqual('19290951279=19166174600');
+
+    const experimentOnly = getExperimentTuple({
+      "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+    }, 'id');
+
+    expect(experimentOnly).toEqual('19290951279');
+  });
+
+  test('tuple delimiter can be customized', () => {
+    const experimentAndVariant = getExperimentTuple({
+      "experiment": { "id": "19290951279", "name": "July 4th Banner" },
+      "variation": { "id": "19166174600", "name": "Full Screen " },
+    }, 'name', ':');
+
+    expect(experimentAndVariant).toEqual('July 4th Banner:Full Screen');
+  });
+});

--- a/dist/optimizely-page-vars.js
+++ b/dist/optimizely-page-vars.js
@@ -1,0 +1,57 @@
+(function () {
+  'use strict';
+
+  function fs(api) {
+    if (!window._fs_namespace) {
+      console.error(`FullStory unavailable, window["_fs_namespace"] must be defined`);
+      return undefined;
+    } else {
+      return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
+    }
+  }
+  function hasFs() {
+    return typeof fs() === 'function';
+  }
+
+  function optimizely(api) {
+    return api ? window.optimizely.get(api) : window.optimizely;
+  }
+  function getExperimentTuple(campaign, property, delimiter) {
+    return campaign.variation ? campaign.experiment[property].trim() + (delimiter || '=') + campaign.variation[property].trim() :
+      campaign.experiment[property].trim();
+  }
+  function campaignsToPageVars(campaignsObj) {
+    const campaignsList = campaignsToList(campaignsObj);
+    return campaignsList.reduce(function (pageVars, campaign) {
+      if (!campaign.isInCampaignHoldback) {
+        pageVars.optimizely_experiment_names.push(getExperimentTuple(campaign, 'name'));
+        pageVars.optimizely_experiment_ids.push(getExperimentTuple(campaign, 'id'));
+      }
+      return pageVars;
+    }, {
+      optimizely_experiment_names: [],
+      optimizely_experiment_ids: []
+    });
+  }
+  function campaignsToList(campaignsObj) {
+    const list = [];
+    const props = Object.getOwnPropertyNames(campaignsObj);
+    for (let i = 0; i < props.length; i += 1) {
+      if (typeof campaignsObj[props[i]] === 'object') {
+        list.push(campaignsObj[props[i]]);
+      }
+    }
+    return list;
+  }
+  function getActiveCampaigns() {
+    return optimizely('state').getCampaignStates({ isActive: true });
+  }
+
+  const utils = optimizely('utils');
+  utils.waitUntil(hasFs).then(function () {
+    const activeCampaigns = getActiveCampaigns();
+    const pageVars = campaignsToPageVars(activeCampaigns);
+    fs('setVars')('page', pageVars);
+  });
+
+}());

--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,6 +2348,12 @@
       "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3616,6 +3622,17 @@
         "supports-color": "^7.0.0"
       }
     },
+    "js-cleanup": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.2.0.tgz",
+      "integrity": "sha512-JeDD0yiiSt80fXzAVa/crrS0JDPQljyBG/RpOtaSbyDq03VHa9szJWMaWOYU/bcTn412uMN2MxApXq8v79cUiQ==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.7",
+        "perf-regexes": "^1.0.1",
+        "skip-regex": "^1.0.2"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3750,6 +3767,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -4174,6 +4200,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "perf-regexes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/perf-regexes/-/perf-regexes-1.0.1.tgz",
+      "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4453,6 +4485,25 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-cleanup": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.2.1.tgz",
+      "integrity": "sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==",
+      "dev": true,
+      "requires": {
+        "js-cleanup": "^1.2.0",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -4699,6 +4750,12 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
+    "skip-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/skip-regex/-/skip-regex-1.0.2.tgz",
+      "integrity": "sha512-pEjMUbwJ5Pl/6Vn6FsamXHXItJXSRftcibixDmNCWbWhic0hzHrwkMZo0IZ7fMRH9KxcWDFSkzhccB4285PutA==",
+      "dev": true
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4866,6 +4923,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-env": "^7.14.7",
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
-    "rollup": "^2.53.2"
+    "rollup": "^2.53.2",
+    "rollup-plugin-cleanup": "^3.2.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,16 @@
 import cleanup from 'rollup-plugin-cleanup';
+import * as fs from 'fs';
 
-export default [
-  {
-    input: 'src/optimizely-page-vars.js',
+const samples = fs.readdirSync(`${__dirname}/src`).filter(filename => filename.endsWith('.js'));
+const options = samples.map(filename => {
+  return {
+    input: `src/${filename}`,
     output: {
-      file: __dirname + '/dist/optimizely-page-vars.js',
+      file: __dirname + `/dist/${filename}`,
       format: 'iife'
     },
-    plugins: [cleanup()]
-  },
-]
+    plugins: [cleanup()],
+  };
+});
+
+export default options;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,12 @@
-export default [
+import cleanup from 'rollup-plugin-cleanup';
 
+export default [
+  {
+    input: 'src/optimizely-page-vars.js',
+    output: {
+      file: __dirname + '/dist/optimizely-page-vars.js',
+      format: 'iife'
+    },
+    plugins: [cleanup()]
+  },
 ]

--- a/src/optimizely-page-vars.js
+++ b/src/optimizely-page-vars.js
@@ -1,0 +1,13 @@
+import { fs, hasFs } from './utils/fs';
+import { optimizely, campaignsToPageVars, getActiveCampaigns } from './utils/optimizely';
+
+/**
+ * Send Optimizely A/B experiments to FullStory using the Page Vars API.
+ * Note, the Page Vars API is available in snippets deployed after April 2020.
+ */
+const utils = optimizely('utils');
+utils.waitUntil(hasFs).then(function () {
+  const activeCampaigns = getActiveCampaigns();
+  const pageVars = campaignsToPageVars(activeCampaigns);
+  fs('setVars')('page', pageVars);
+});

--- a/src/utils/optimizely.js
+++ b/src/utils/optimizely.js
@@ -1,0 +1,61 @@
+
+/**
+ * Gets the Optimizely SDK from the window.
+ * @param api Optional Optimizely API via https://docs.developers.optimizely.com/web/docs/get
+ */
+export function optimizely(api) {
+  return api ? window.optimizely.get(api) : window.optimizely;
+}
+
+/**
+ * Returns a tuple of experiment and variant values.
+ * @param campaign CampaignStateObject
+ * @param property Property in the CampaignStateObject (e.g. `name` or `id`)
+ * @param delimiter String that separates the experiment and variant names (defaults to =)
+ */
+export function getExperimentTuple(campaign, property, delimiter) {
+  return campaign.variation ? campaign.experiment[property].trim() + (delimiter || '=') + campaign.variation[property].trim() :
+    campaign.experiment[property].trim();
+}
+
+/**
+ * Creates a FS.PageVars payload with experiment data.
+ * @param campaignsObj A map of campaign IDs to CampaignStateObjects
+ */
+export function campaignsToPageVars(campaignsObj) {
+  const campaignsList = campaignsToList(campaignsObj);
+  return campaignsList.reduce(function (pageVars, campaign) {
+    if (!campaign.isInCampaignHoldback) {
+      pageVars.optimizely_experiment_names.push(getExperimentTuple(campaign, 'name'));
+      pageVars.optimizely_experiment_ids.push(getExperimentTuple(campaign, 'id'));
+    }
+
+    return pageVars;
+  }, {
+    optimizely_experiment_names: [],
+    optimizely_experiment_ids: []
+  });
+}
+
+/**
+ * Converts the campaigns object to a list of CampaignStateObjects.
+ * @param campaignsObj A map of campaign IDs to CampaignStateObjects
+ */
+export function campaignsToList(campaignsObj) {
+  const list = [];
+  const props = Object.getOwnPropertyNames(campaignsObj);
+  for (let i = 0; i < props.length; i += 1) {
+    if (typeof campaignsObj[props[i]] === 'object') {
+      list.push(campaignsObj[props[i]]);
+    }
+  }
+  return list;
+}
+
+/**
+ * Get all the campaigns and their current states.
+ * https://docs.developers.optimizely.com/web/docs/state#section-get-campaign-states
+ */
+export function getActiveCampaigns() {
+  return optimizely('state').getCampaignStates({ isActive: true });
+}


### PR DESCRIPTION
@djwhatley-fs Thought you might want to see this one since it's a different take on our existing integration in the [KB](https://help.fullstory.com/hc/en-us/articles/360020624054-Optimizely-).  Of note, the KB code is prone to rate limiting and experiments are better packaged as a single payload versus multiple `FS.event` calls.

The `dist/optimizely-page-vars.js` file can be ignored for code review; it's just the compiled version of `src/optimizely-page-vars.js`.  I'm committing dist output because it'll be easier to reference than ask people to clone and build themselves.

I think the modular approach, mocks, and utilities will help refactor additional KB integrations as well as add new ones.