### PR TITLE
Session stitching example

### DIFF
--- a/__mocks__/_fs_identity.js
+++ b/__mocks__/_fs_identity.js
@@ -1,0 +1,14 @@
+
+// adds an _fs_identity predicate function
+// this simulates checking Adobe marketingCloudVisitorID as the UID
+Object.defineProperty(window, '_fs_identity', {
+  writable: false,
+  value: () => {
+    if (window.s && window.s.marketingCloudVisitorID) {
+      return {
+        uid: window.s.marketingCloudVisitorID,
+        displayName: s.eVar1,
+      }
+    }
+  }
+});

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -7,6 +7,7 @@ Object.defineProperty(window, '_fs_namespace', {
 const FS = () => { };
 FS.event = jest.fn();
 FS.identify = jest.fn();
+FS.log = jest.fn();
 FS.restart = jest.fn();
 FS.setVars = jest.fn();
 FS.setUserVars = jest.fn();

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -7,8 +7,10 @@ Object.defineProperty(window, '_fs_namespace', {
 const FS = () => { };
 FS.event = jest.fn();
 FS.identify = jest.fn();
+FS.restart = jest.fn();
 FS.setVars = jest.fn();
 FS.setUserVars = jest.fn();
+FS.shutdown = jest.fn();
 
 // NOTE this will always use the exemplar `FS` namespace
 Object.defineProperty(window, 'FS', {

--- a/__tests__/fs-session-stitching.spec.js
+++ b/__tests__/fs-session-stitching.spec.js
@@ -1,6 +1,7 @@
 import '../__mocks__/fs';
+import '../__mocks__/_fs_identity';
 import { fs } from '../src/utils/fs';
-import '../src/fs-session-stitching';
+import '../src/fs-session-stitching'; // NOTE the script will execute and begin its timeout timer here
 
 describe('FullStory session stitching', () => {
   test('recording is delayed until identity is known', (done) => {
@@ -8,17 +9,23 @@ describe('FullStory session stitching', () => {
     expect(fs('setUserVars')).toBeCalledTimes(0);
     expect(fs('restart')).toBeCalledTimes(0);
 
-    // simulate an async function that determines user identity
+    // simulate an async function that provides user identity
     setTimeout(() => {
-      window._fs_user_identity = {
-        uid: `${Date.now()}`,
-      }
+      window.s = {
+        marketingCloudVisitorID: 'fuLlSt0ry',
+        eVar1: 'FullStory',
+      };
     }, 100);
 
     // wait a longer period of time to check the calls to FS
     setTimeout(() => {
+      expect(window._fs_identity).toBeDefined();
+      expect(window.s).toBeDefined();
+      expect(fs('log')).toBeCalledTimes(0); // no FS.log() error messages should exist
       expect(fs('shutdown')).toBeCalledTimes(1);
       expect(fs('setUserVars')).toBeCalledTimes(1);
+      expect(fs('setUserVars').mock.calls[0][0].uid).toEqual('fuLlSt0ry');
+      expect(fs('setUserVars').mock.calls[0][0].displayName).toEqual('FullStory');
       expect(fs('restart')).toBeCalledTimes(1);
 
       done();

--- a/__tests__/fs-session-stitching.spec.js
+++ b/__tests__/fs-session-stitching.spec.js
@@ -1,0 +1,27 @@
+import '../__mocks__/fs';
+import { fs } from '../src/utils/fs';
+import '../src/fs-session-stitching';
+
+describe('FullStory session stitching', () => {
+  test('recording is delayed until identity is known', (done) => {
+    expect(fs('shutdown')).toBeCalled();
+    expect(fs('setUserVars')).toBeCalledTimes(0);
+    expect(fs('restart')).toBeCalledTimes(0);
+
+    // simulate an async function that determines user identity
+    setTimeout(() => {
+      window._fs_user_identity = {
+        uid: `${Date.now()}`,
+      }
+    }, 100);
+
+    // wait a longer period of time to check the calls to FS
+    setTimeout(() => {
+      expect(fs('shutdown')).toBeCalledTimes(1);
+      expect(fs('setUserVars')).toBeCalledTimes(1);
+      expect(fs('restart')).toBeCalledTimes(1);
+
+      done();
+    }, 2000);
+  });
+});

--- a/__tests__/fs-utils.spec.js
+++ b/__tests__/fs-utils.spec.js
@@ -1,5 +1,5 @@
 import '../__mocks__/fs';
-import { fs, hasFs } from '../src/utils/fs';
+import { fs, hasFs, waitUntil } from '../src/utils/fs';
 
 describe('FullStory utilities', () => {
   test('Recording API exists in the window', () => {
@@ -36,5 +36,12 @@ describe('FullStory utilities', () => {
     fs('setUserVars')({ displayName: 'FullStory' });
     expect(fs('setUserVars')).toHaveBeenCalled();
     expect(fs('setUserVars').mock.calls[0][0]).toBeDefined();
+  });
+
+  test('function can be polled and called', (done) => {
+    waitUntil(() => window._fs_jest, done, 2000)();
+    setTimeout(() => {
+      window._fs_jest = true;
+    }, 250);
   });
 });

--- a/__tests__/fs-utils.spec.js
+++ b/__tests__/fs-utils.spec.js
@@ -39,9 +39,35 @@ describe('FullStory utilities', () => {
   });
 
   test('function can be polled and called', (done) => {
-    waitUntil(() => window._fs_jest, done, 2000)();
+    const timeout = 2000;  // milliseconds
+
+    const callbackFn = () => {
+      const end = Date.now();
+      expect(end).toBeLessThan(start + timeout);
+      done();
+    }
+
+    const start = Date.now();
+    waitUntil(() => window[start], callbackFn, timeout);
     setTimeout(() => {
-      window._fs_jest = true;
+      window[start] = true;
     }, 250);
+  });
+
+  test('timeout function can be used as a fallback case', (done) => {
+    const timeout = 500;  // milliseconds
+
+    const predicateFn = jest.fn();
+    const callbackFn = jest.fn();
+    const timeoutFn = () => {
+      const end = Date.now();
+      expect(end).toBeGreaterThanOrEqual(start + timeout);
+      expect(predicateFn).toBeCalled();
+      expect(callbackFn).toBeCalledTimes(0);
+      done();
+    }
+
+    const start = Date.now();
+    waitUntil(predicateFn, callbackFn, timeout, timeoutFn);
   });
 });

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -26,9 +26,10 @@
       totalTime += delay;
       setTimeout(resultFn, delay);
     };
-    return resultFn;
+    resultFn();
   }
 
+  const timeout = 2000;
   function identify() {
     const userVars = window._fs_user_identity;
     if (!userVars || !userVars.uid) {
@@ -41,6 +42,6 @@
   fs('shutdown')();
   waitUntil(function () {
     return window._fs_user_identity;
-  }, identify, 2000, fs('restart'))();
+  }, identify, timeout, fs('restart'));
 
 }());

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -13,7 +13,7 @@
     let totalTime = 0;
     let delay = 64;
     const resultFn = function () {
-      if (predicateFn()) {
+      if (typeof predicateFn === 'function' && predicateFn()) {
         callbackFn();
         return;
       }
@@ -31,17 +31,19 @@
 
   const timeout = 2000;
   function identify() {
-    const userVars = window._fs_user_identity;
-    if (!userVars || !userVars.uid) {
-      console.error('FS.identify requires user variables to exist and contain uid');
+    if (typeof window._fs_identity === 'function') {
+      const userVars = window._fs_identity();
+      if (typeof userVars === 'object' && typeof userVars.uid === 'string') {
+        fs('setUserVars')(userVars);
+        fs('restart')();
+      } else {
+        fs('log')('error', 'FS.setUserVars requires an object that contains uid');
+      }
     } else {
-      fs('setUserVars')(userVars);
-      fs('restart')();
+      fs('log')('error', 'window["_fs_identity"] function not found');
     }
   }
   fs('shutdown')();
-  waitUntil(function () {
-    return window._fs_user_identity;
-  }, identify, timeout, fs('restart'));
+  waitUntil(window._fs_identity, identify, timeout, fs('restart'));
 
 }());

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -1,0 +1,46 @@
+(function () {
+  'use strict';
+
+  function fs(api) {
+    if (!window._fs_namespace) {
+      console.error(`FullStory unavailable, window["_fs_namespace"] must be defined`);
+      return undefined;
+    } else {
+      return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
+    }
+  }
+  function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
+    let totalTime = 0;
+    let delay = 64;
+    const resultFn = function () {
+      if (predicateFn()) {
+        callbackFn();
+        return;
+      }
+      delay = Math.min(delay * 2, 1024);
+      if (totalTime > timeout) {
+        if (timeoutFn) {
+          timeoutFn();
+        }
+      }
+      totalTime += delay;
+      setTimeout(resultFn, delay);
+    };
+    return resultFn;
+  }
+
+  function identify() {
+    const userVars = window._fs_user_identity;
+    if (!userVars || !userVars.uid) {
+      console.error('FS.identify requires user variables to exist and contain uid');
+    } else {
+      fs('setUserVars')(userVars);
+      fs('restart')();
+    }
+  }
+  fs('shutdown')();
+  waitUntil(function () {
+    return window._fs_user_identity;
+  }, identify, 2000, fs('restart'))();
+
+}());

--- a/src/fs-session-stitching.js
+++ b/src/fs-session-stitching.js
@@ -1,0 +1,31 @@
+import { fs, waitUntil } from './utils/fs';
+
+/**
+ * Demonstrates cross-domain session stitching, which involves delaying recording until a persistent
+ * user ID can be passed to `FS.identify`.
+ */
+
+/**
+ * Get `window._fs_user_identity` for an object containing user vars, identify the user, and resume recording.
+ * The object returned must contain `uid` and can optionally contain additional properties per
+ * https://help.fullstory.com/hc/en-us/articles/360020623294.
+ */
+function identify() {
+  const userVars = window._fs_user_identity;
+
+  if (!userVars || !userVars.uid) {
+    console.error('FS.identify requires user variables to exist and contain uid');
+  } else {
+    fs('setUserVars')(userVars);
+    fs('restart')();
+  }
+}
+
+// immediately call `FS.shutdown` after loading the snippet
+fs('shutdown')();
+
+// wait until a UID is available or timeout and resume recording
+waitUntil(function () {
+  // check `window._fs_user_identity` for an object containing user vars or a falsy value
+  return window._fs_user_identity;
+}, identify, 2000, fs('restart'))();

--- a/src/fs-session-stitching.js
+++ b/src/fs-session-stitching.js
@@ -1,9 +1,12 @@
 import { fs, waitUntil } from './utils/fs';
 
 /**
- * Demonstrates cross-domain session stitching, which involves delaying recording until a persistent
- * user ID can be passed to `FS.identify`.
+ * Demonstrates cross-domain session stitching, which involves delaying recording until `window._fs_user_identity`
+ * is assigned an object that contains `uid` or `timeout` is reached. This code must immediately execute after loading
+ * the FullStory snippet.
  */
+
+const timeout = 2000;
 
 /**
  * Get `window._fs_user_identity` for an object containing user vars, identify the user, and resume recording.
@@ -28,4 +31,4 @@ fs('shutdown')();
 waitUntil(function () {
   // check `window._fs_user_identity` for an object containing user vars or a falsy value
   return window._fs_user_identity;
-}, identify, 2000, fs('restart'))();
+}, identify, timeout, fs('restart'));

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -31,9 +31,8 @@ export function hasFs() {
 export function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
   let totalTime = 0;
   let delay = 64;
-
   const resultFn = function () {
-    if (predicateFn()) {
+    if (typeof predicateFn === 'function' && predicateFn()) {
       callbackFn();
       return;
     }

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -19,3 +19,36 @@ export function fs(api) {
 export function hasFs() {
   return typeof fs() === 'function';
 }
+
+/**
+ * Waits until a `predicateFn` returns truthy and executes a `callbackFn`.
+ * This function will exponentially backoff and wait up to 1024ms until `timeout` is reached.
+ * @param predicateFn Tests if the `callbackFn` should run
+ * @param callbackFn Callback function to execute when the `predicateFn` is truthy
+ * @param timeout Number of milliseconds to wait before giving up
+ * @param timeoutFn Optional function executed when the timeout is reached
+ */
+export function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
+  let totalTime = 0;
+  let delay = 64;
+
+  const resultFn = function () {
+    if (predicateFn()) {
+      callbackFn();
+      return;
+    }
+
+    delay = Math.min(delay * 2, 1024);
+
+    if (totalTime > timeout) {
+      if (timeoutFn) {
+        timeoutFn();
+      }
+    }
+
+    totalTime += delay
+    setTimeout(resultFn, delay);
+  };
+
+  return resultFn;
+}

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -40,13 +40,13 @@ export function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
     delay = Math.min(delay * 2, 1024);
 
     if (totalTime > timeout) {
-      if (timeoutFn) {
+      if (typeof timeoutFn === 'function') {
         timeoutFn();
       }
+    } else {
+      totalTime += delay
+      setTimeout(resultFn, delay);
     }
-
-    totalTime += delay
-    setTimeout(resultFn, delay);
   };
 
   resultFn();

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -50,5 +50,5 @@ export function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
     setTimeout(resultFn, delay);
   };
 
-  return resultFn;
+  resultFn();
 }


### PR DESCRIPTION
This example demonstrates how we can approach session stitching using `FS.setUserVars`/`FS.identify`.  The IIFE that gets created from this can be added immediately after the FullStory snippet.  The design is such that the IIFE shuts down recording using `FS.shutdown`.  It then waits for a `uid` to become available at which point `FS.setUserVars` is called (essentially `FS.identify`) and restarts recording.  Of note, this allows the customer to define an `_fs_identify` predicate function to check if user identity is known, which I though follows a similar pattern of function declaration a la `_fs_ready`.