### PR TITLE
Medallia example

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -12,6 +12,6 @@ FS.setUserVars = jest.fn();
 
 // NOTE this will always use the exemplar `FS` namespace
 Object.defineProperty(window, 'FS', {
-  writable: false,
+  writable: true, // allows removing and re-adding FS within tests
   value: FS,
 });

--- a/__mocks__/medallia.js
+++ b/__mocks__/medallia.js
@@ -1,0 +1,8 @@
+Object.defineProperty(window, 'KAMPYLE_SDK', {
+  writable: false,
+  value: {
+    kampyleSubmit: (data) => {
+      window.dispatchEvent(new CustomEvent('MDigital_Submit_Feedback', { detail: data }));
+    },
+  }
+});

--- a/__tests__/medallia.spec.js
+++ b/__tests__/medallia.spec.js
@@ -1,0 +1,50 @@
+import '../__mocks__/fs';
+import '../__mocks__/medallia';
+import { fs } from '../src/utils/fs';
+import '../src/medallia';
+
+const MDigital_Submit_Feedback = {
+  Form_ID: '25266',
+  Form_Type: 'Intercept',
+  Feedback_UUID: '1053-d865-ee90-1c9a-f81c-6965-c8ab-6b7d',
+  Content: [
+    {
+      id: 421498,
+      type: 'nps',
+      unique_name: 'NPS',
+      value: 9,
+    },
+    {
+      id: 552090,
+      type: 'grading1to10',
+      unique_name: 'Driver1_NPS',
+      value: 6,
+    },
+    {
+      id: 422869,
+      type: 'grading1to10',
+      unique_name: 'OSAT_7_DIY_Home',
+      value: 7
+    }
+  ],
+};
+
+describe('Medallia Feedback', () => {
+  test('send feedback to FS.event and FS.setUserVars', () => {
+    // manually trigger feedback submission
+    window.KAMPYLE_SDK.kampyleSubmit(MDigital_Submit_Feedback);
+
+    expect(fs('setUserVars')).toBeCalled();
+    expect(fs('setUserVars').mock.calls[0][0]).toEqual({ NPS: 9 });
+
+    expect(fs('event')).toBeCalled();
+    expect(fs('event').mock.calls[0][0]).toEqual('Medallia Feedback');
+    expect(fs('event').mock.calls[0][1]).toEqual({
+      Form_ID: '25266',
+      Form_Type: 'Intercept',
+      Feedback_UUID: '1053-d865-ee90-1c9a-f81c-6965-c8ab-6b7d',
+      Driver1_NPS: 6,
+      OSAT_7_DIY_Home: 7,
+    });
+  });
+});

--- a/dist/medallia.js
+++ b/dist/medallia.js
@@ -1,0 +1,44 @@
+(function () {
+  'use strict';
+
+  function fs(api) {
+    if (!hasFs()) {
+      return function () {
+        console.error(`FullStory unavailable, check your snippet or tag`);
+      }
+    } else {
+      if (api && !window[window._fs_namespace][api]) {
+        return function () {
+          console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
+        }
+      }
+      return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
+    }
+  }
+  function hasFs() {
+    return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
+  }
+
+  function handleSubmitFeedback(event) {
+    const detail = event.detail;
+    if (!detail) {
+      fs('log')('warn', 'MDigital_Submit_Feedback data not found');
+      return;
+    }
+    const payload = {
+      Form_Type: detail.Form_Type,
+      Form_ID: detail.Form_ID,
+      Feedback_UUID: detail.Feedback_UUID,
+    };
+    for (let i = 0; i < detail.Content.length; i += 1) {
+      if (detail.Content[i].unique_name === 'NPS') {
+        fs('setUserVars')({ NPS: detail.Content[i].value });
+      } else {
+        payload[detail.Content[i].unique_name] = detail.Content[i].value;
+      }
+    }
+    fs('event')('Medallia Feedback', payload);
+  }
+  window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
+
+}());

--- a/dist/optimizely-page-vars.js
+++ b/dist/optimizely-page-vars.js
@@ -2,15 +2,21 @@
   'use strict';
 
   function fs(api) {
-    if (!window._fs_namespace) {
-      console.error(`FullStory unavailable, window["_fs_namespace"] must be defined`);
-      return undefined;
+    if (!hasFs()) {
+      return function () {
+        console.error(`FullStory unavailable, check your snippet or tag`);
+      }
     } else {
+      if (api && !window[window._fs_namespace][api]) {
+        return function () {
+          console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
+        }
+      }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
     }
   }
   function hasFs() {
-    return typeof fs() === 'function';
+    return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
   }
 
   function optimizely(api) {

--- a/src/medallia.js
+++ b/src/medallia.js
@@ -1,0 +1,34 @@
+import { fs } from './utils/fs';
+
+/**
+ * Handles the MDigital_Submit_Feedback event:
+ * - Attributes NPS score to user using `FS.setUserVars`
+ * - Creates a single "Medallia Feedback" with content name value pairs
+ * @param event MDigital_Submit_Feedback event
+ */
+function handleSubmitFeedback(event) {
+  const detail = event.detail;
+
+  if (!detail) {
+    fs('log')('warn', 'MDigital_Submit_Feedback data not found');
+    return;
+  }
+
+  const payload = {
+    Form_Type: detail.Form_Type,
+    Form_ID: detail.Form_ID,
+    Feedback_UUID: detail.Feedback_UUID,
+  };
+
+  for (let i = 0; i < detail.Content.length; i += 1) {
+    if (detail.Content[i].unique_name === 'NPS') {
+      fs('setUserVars')({ NPS: detail.Content[i].value });
+    } else {
+      payload[detail.Content[i].unique_name] = detail.Content[i].value;
+    }
+  }
+
+  fs('event')('Medallia Feedback', payload);
+}
+
+window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -4,10 +4,17 @@
  * @returns The FullStory "FS" function or a specific API as a function
  */
 export function fs(api) {
-  if (!window._fs_namespace) {
-    console.error(`FullStory unavailable, window["_fs_namespace"] must be defined`);
-    return undefined;
+  if (!hasFs()) {
+    return function () {
+      console.error(`FullStory unavailable, check your snippet or tag`);
+    }
   } else {
+    // guard against older snippets that may not define an API
+    if (api && !window[window._fs_namespace][api]) {
+      return function () {
+        console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
+      }
+    }
     return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
   }
 }
@@ -17,5 +24,5 @@ export function fs(api) {
  * @returns True if the recording API exists and has the function type
  */
 export function hasFs() {
-  return typeof fs() === 'function';
+  return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
 }


### PR DESCRIPTION
@djwhatley-fs Thought you might like to review this Medallia sample.  Something I've noticed with more advanced implementations is that people try to `FS.event` on each feedback item.  Above 10, that causes rate limiting.  So this consolidates the feedback items into a single dictionary for `FS.event`.  I also have a `FS.setUserVars` if the feedback specifically contains NPS feedback.

There's a mock implementation of the Medallia SDK and a few tweaks on my `utils` helper functions.  You can ignore the `dist` files for the purposes of code review.  Those get regenerated whenever I build (the Optimizely sample changed to reflect the adjustments to the `util` helpers).  Let me know if you have questions.

Side note, today I'm adding built samples to `dist`, but in the future I'd like to create a README.md for each sample and then interpolate the built sample to some portion of the readme.