### PR TITLE
Sampling example

### DIFF
--- a/__tests__/fs-utils.spec.js
+++ b/__tests__/fs-utils.spec.js
@@ -95,21 +95,28 @@ describe('FullStory utilities', () => {
 
   test('sampling rate can be configured', () => {
     const rate = 10; // 10% sample rate
-    const margin = 2.5 * (100 / rate); // give it 2.5x margin of random error to ensure the test concludes
+    const numTests = 100 / rate;
 
-    let i = 0;
-    while (i <= margin) {
-      if (sample(rate, 30)) {
-        break;
-      } else {
-        expect(document.cookie).toContain('_fs_sample_user=false');
-        // manually clear the cookie that was set in the `sample` function
-        document.cookie = '_fs_sample_user=; path=/';
-        i++;
+    let success = false;
+
+    for (let i = 0; i < numTests; i += 1) {
+      for (let j = 0; j < rate; j += 1) {
+        // check the random result
+        if (sample(rate, 30)) {
+          // if it's true, the user is sampled and mark success
+          success = true;
+        } else {
+          // if the user was not sampled, a cookie has been set
+          expect(document.cookie).toContain('_fs_sample_user=false');
+          // manually clear the cookie that was set in the `sample` function
+          // to allow for another random result
+          document.cookie = '_fs_sample_user=; path=/';
+        }
       }
     }
 
-    expect(i).toBeLessThan(margin);
+    // after `numTests` the expectation is that the user *should have* been randomly sampled
+    expect(success).toEqual(true);
     expect(document.cookie).toContain('_fs_sample_user=true');
     expect(document.cookie).not.toContain('_fs_sample_user=false');
   });
@@ -120,15 +127,19 @@ describe('FullStory utilities', () => {
 
     const samples = [];
 
+    // manually set to cookie to sample the user
     document.cookie = '_fs_sample_user=true; path=/';
 
+    // run a sufficient number of tests to overcome
     for (let i = 0; i < numTests; i += 1) {
       samples[i] = sample(rate);
     }
 
+    // for every sample result, expect the existing cookie's value to be used
     expect(samples).toContain(true);
     expect(samples).not.toContain(false);
 
+    // do the exact same as the above but for the non-sample scenario
     document.cookie = '_fs_sample_user=false; path=/';
 
     for (let i = 0; i < numTests; i += 1) {
@@ -142,8 +153,11 @@ describe('FullStory utilities', () => {
   test('invalid _fs_sample_user cookie re-samples', () => {
     const rate = 10; // 10% sample rate
 
+    // set the existing cookie to something invalid (i.e. anything other than true or false)
     document.cookie = `_fs_sample_user=test; path=/`;
 
+    // this will cause the `sample` function to run and randomly sample
+    // and overwrites the invalid cookie
     const shouldSample = sample(rate);
     expect(document.cookie).toEqual(`_fs_sample_user=${shouldSample}`);
   });

--- a/__tests__/fs-utils.spec.js
+++ b/__tests__/fs-utils.spec.js
@@ -1,5 +1,5 @@
 import '../__mocks__/fs';
-import { fs, hasFs, waitUntil } from '../src/utils/fs';
+import { fs, hasFs, sample, waitUntil } from '../src/utils/fs';
 
 const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -91,5 +91,26 @@ describe('FullStory utilities', () => {
 
     const start = Date.now();
     waitUntil(predicateFn, callbackFn, timeout, timeoutFn);
+  });
+
+  test('sampling rate can be configured', () => {
+    const rate = 10; // 10% sample rate
+    const margin = 2 * (100 / rate); // give it 2x margin of random error to ensure the test concludes
+
+    let i = 0;
+    while (i <= margin) {
+      if (sample(rate, 30)) {
+        break;
+      } else {
+        expect(document.cookie).toContain('_fs_sample_user=false');
+        // manually clear the cookie that was set in the `sample` function
+        document.cookie = `_fs_sample_user=; path=/`;
+        i++;
+      }
+    }
+
+    expect(i).toBeLessThan(margin);
+    expect(document.cookie).toContain('_fs_sample_user=true');
+    expect(document.cookie).not.toContain('_fs_sample_user=false');
   });
 });

--- a/__tests__/fs-utils.spec.js
+++ b/__tests__/fs-utils.spec.js
@@ -95,7 +95,7 @@ describe('FullStory utilities', () => {
 
   test('sampling rate can be configured', () => {
     const rate = 10; // 10% sample rate
-    const margin = 2 * (100 / rate); // give it 2x margin of random error to ensure the test concludes
+    const margin = 2.5 * (100 / rate); // give it 2.5x margin of random error to ensure the test concludes
 
     let i = 0;
     while (i <= margin) {
@@ -104,7 +104,7 @@ describe('FullStory utilities', () => {
       } else {
         expect(document.cookie).toContain('_fs_sample_user=false');
         // manually clear the cookie that was set in the `sample` function
-        document.cookie = `_fs_sample_user=; path=/`;
+        document.cookie = '_fs_sample_user=; path=/';
         i++;
       }
     }
@@ -112,5 +112,39 @@ describe('FullStory utilities', () => {
     expect(i).toBeLessThan(margin);
     expect(document.cookie).toContain('_fs_sample_user=true');
     expect(document.cookie).not.toContain('_fs_sample_user=false');
+  });
+
+  test('existing _fs_sample_user cookie value should be re-used', () => {
+    const numTests = 100;
+    const rate = 10; // 10% sample rate
+
+    const samples = [];
+
+    document.cookie = '_fs_sample_user=true; path=/';
+
+    for (let i = 0; i < numTests; i += 1) {
+      samples[i] = sample(rate);
+    }
+
+    expect(samples).toContain(true);
+    expect(samples).not.toContain(false);
+
+    document.cookie = '_fs_sample_user=false; path=/';
+
+    for (let i = 0; i < numTests; i += 1) {
+      samples[i] = sample(rate);
+    }
+
+    expect(samples).toContain(false);
+    expect(samples).not.toContain(true);
+  });
+
+  test('invalid _fs_sample_user cookie re-samples', () => {
+    const rate = 10; // 10% sample rate
+
+    document.cookie = `_fs_sample_user=test; path=/`;
+
+    const shouldSample = sample(rate);
+    expect(document.cookie).toEqual(`_fs_sample_user=${shouldSample}`);
   });
 });

--- a/dist/sampling.js
+++ b/dist/sampling.js
@@ -4,18 +4,18 @@
   function sample(rate, daysValid) {
     var cookieName = '_fs_sample_user';
     try {
-      if (document.cookie.indexOf("".concat(cookieName, "=true")) > -1 || document.cookie.indexOf("".concat(cookieName, "=false")) > -1) {
-        return document.cookie.indexOf("".concat(cookieName, "=true")) > -1;
+      if (document.cookie.indexOf(cookieName + '=true') > -1 || document.cookie.indexOf(cookieName + '=false') > -1) {
+        return document.cookie.indexOf(cookieName + '=true') > -1;
       } else {
         var shouldSample = Math.random() < rate / 100;
         var days = daysValid !== undefined && daysValid > 0 ? daysValid : 30;
         var date = new Date();
         date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-        document.cookie = "".concat(cookieName, "=").concat(shouldSample, "; expires=").concat(date.toGMTString(), "; path=/");
+        document.cookie = cookieName + '=' + shouldSample + '; expires=' + date.toGMTString() + '; path=/';
         return shouldSample;
       }
     } catch (err) {
-      console.error("FullStory unavailable, unable to sample user");
+      console.error('FullStory unavailable, unable to sample user');
       return false;
     }
   }

--- a/dist/sampling.js
+++ b/dist/sampling.js
@@ -2,26 +2,26 @@
   'use strict';
 
   function sample(rate, daysValid) {
-    const cookieName = '_fs_sample_user';
+    var cookieName = '_fs_sample_user';
     try {
-      if (document.cookie.indexOf(`${cookieName}=true`) > -1 || document.cookie.indexOf(`${cookieName}=false`) > -1) {
-        return document.cookie.indexOf(`${cookieName}=true`) > -1;
+      if (document.cookie.indexOf("".concat(cookieName, "=true")) > -1 || document.cookie.indexOf("".concat(cookieName, "=false")) > -1) {
+        return document.cookie.indexOf("".concat(cookieName, "=true")) > -1;
       } else {
-        const shouldSample = (Math.random() < (rate / 100));
-        const days = (daysValid !== undefined && daysValid > 0) ? daysValid : 30;
-        const date = new Date();
-        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-        document.cookie = `${cookieName}=${shouldSample}; expires=${date.toGMTString()}; path=/`;
+        var shouldSample = Math.random() < rate / 100;
+        var days = daysValid !== undefined && daysValid > 0 ? daysValid : 30;
+        var date = new Date();
+        date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+        document.cookie = "".concat(cookieName, "=").concat(shouldSample, "; expires=").concat(date.toGMTString(), "; path=/");
         return shouldSample;
       }
     } catch (err) {
-      console.error(`FullStory unavailable, unable to sample user`);
+      console.error("FullStory unavailable, unable to sample user");
       return false;
     }
   }
 
-  const rate = 10;
-  const daysValid = 90;
+  var rate = 10;
+  var daysValid = 90;
   if (sample(rate, daysValid)) {
     console.log('REPLACE THIS LINE WITH YOUR FULLSTORY SNIPPET');
   }

--- a/dist/sampling.js
+++ b/dist/sampling.js
@@ -1,0 +1,29 @@
+(function () {
+  'use strict';
+
+  function sample(rate, daysValid) {
+    const cookieName = '_fs_sample_user';
+    try {
+      if (document.cookie.indexOf(`${cookieName}=true`) > -1 || document.cookie.indexOf(`${cookieName}=false`) > -1) {
+        return document.cookie.indexOf(`${cookieName}=true`) > -1;
+      } else {
+        const shouldSample = (Math.random() < (rate / 100));
+        const days = (daysValid !== undefined && daysValid > 0) ? daysValid : 30;
+        const date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        document.cookie = `${cookieName}=${shouldSample}; expires=${date.toGMTString()}; path=/`;
+        return shouldSample;
+      }
+    } catch (err) {
+      console.error(`FullStory unavailable, unable to sample user`);
+      return false;
+    }
+  }
+
+  const rate = 10;
+  const daysValid = 90;
+  if (sample(rate, daysValid)) {
+    console.log('REPLACE THIS LINE WITH YOUR FULLSTORY SNIPPET');
+  }
+
+}());

--- a/src/sampling.js
+++ b/src/sampling.js
@@ -1,0 +1,11 @@
+import { sample } from './utils/fs';
+
+// sample 10% of users (i.e. 1 out of every 10 users)
+const rate = 10;
+
+// re-sample the user after 90 days have elapsed (i.e. cookie expiration)
+const daysValid = 90;
+
+if (sample(rate, daysValid)) {
+  console.log('REPLACE THIS LINE WITH YOUR FULLSTORY SNIPPET');
+}

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -41,9 +41,9 @@ export function sample(rate, daysValid) {
   try {
     // the sample function has successfully run previously
     // NOTE simply checking the cookie name makes testing difficult; hence, check expected key:value pairs
-    if (document.cookie.indexOf(`${cookieName}=true`) > -1 || document.cookie.indexOf(`${cookieName}=false`) > -1) {
+    if (document.cookie.indexOf(cookieName + '=true') > -1 || document.cookie.indexOf(cookieName + '=false') > -1) {
       // sample if and only if the sample flag has been set to true
-      return document.cookie.indexOf(`${cookieName}=true`) > -1;
+      return document.cookie.indexOf(cookieName + '=true') > -1;
     } else {
       // decide if the user should be sampled and store the result
       const shouldSample = (Math.random() < (rate / 100));
@@ -54,12 +54,12 @@ export function sample(rate, daysValid) {
       date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
 
       // store the cookie
-      document.cookie = `${cookieName}=${shouldSample}; expires=${date.toGMTString()}; path=/`;
+      document.cookie = cookieName + '=' + shouldSample + '; expires=' + date.toGMTString() + '; path=/';
 
       return shouldSample;
     }
   } catch (err) {
-    console.error(`FullStory unavailable, unable to sample user`);
+    console.error('FullStory unavailable, unable to sample user');
     // default to not sampling the user to prevent errors from over-sampling
     return false;
   }


### PR DESCRIPTION
While we advocate full capture, the need for sampling arises and there's no public reference point.   This example demonstrates cookie-based sampling for users to advocate the following best practices:
- Sampling should be done randomly (using an easy to understand/configure approach)
- Once sampled, a user should not be re-sampled.  For example, page-based random sampling results in ragged sessions and invalid metrics in FullStory.
- Sampling should default to not sampling if an error were to occur (i.e. a bug in sampling code should not lead to recording because this leads to traffic spikes)

Of note, I'll submit another PR with babel presets that better align code to fs.js browser support.  The `dist` output in this PR reflects the same.