### PR TITLE
Babel browser targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,10 @@
           "ie": "11",
           "ios": "8",
           "android": "40"
-        }
+        },
+        "exclude": [
+          "@babel/plugin-transform-typeof-symbol"
+        ]
       }
     ]
   ]

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,18 @@
 {
   "presets": [
-    "@babel/preset-env"
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "chrome": "37",
+          "edge": "11",
+          "firefox": "23",
+          "safari": "8",
+          "ie": "11",
+          "ios": "8",
+          "android": "40"
+        }
+      }
+    ]
   ]
 }

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -1,39 +1,65 @@
 (function () {
   'use strict';
 
-  function fs(api) {
-    if (!window._fs_namespace) {
-      console.error(`FullStory unavailable, window["_fs_namespace"] must be defined`);
-      return undefined;
+  function _typeof(obj) {
+    "@babel/helpers - typeof";
+
+    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+      _typeof = function (obj) {
+        return typeof obj;
+      };
     } else {
+      _typeof = function (obj) {
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+      };
+    }
+
+    return _typeof(obj);
+  }
+
+  function fs(api) {
+    if (!hasFs()) {
+      return function () {
+        console.error("FullStory unavailable, check your snippet or tag");
+      };
+    } else {
+      if (api && !window[window._fs_namespace][api]) {
+        return function () {
+          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+        };
+      }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
     }
   }
+  function hasFs() {
+    return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
+  }
   function waitUntil(predicateFn, callbackFn, timeout, timeoutFn) {
-    let totalTime = 0;
-    let delay = 64;
-    const resultFn = function () {
+    var totalTime = 0;
+    var delay = 64;
+    var resultFn = function resultFn() {
       if (typeof predicateFn === 'function' && predicateFn()) {
         callbackFn();
         return;
       }
       delay = Math.min(delay * 2, 1024);
       if (totalTime > timeout) {
-        if (timeoutFn) {
+        if (typeof timeoutFn === 'function') {
           timeoutFn();
         }
+      } else {
+        totalTime += delay;
+        setTimeout(resultFn, delay);
       }
-      totalTime += delay;
-      setTimeout(resultFn, delay);
     };
     resultFn();
   }
 
-  const timeout = 2000;
+  var timeout = 2000;
   function identify() {
     if (typeof window._fs_identity === 'function') {
-      const userVars = window._fs_identity();
-      if (typeof userVars === 'object' && typeof userVars.uid === 'string') {
+      var userVars = window._fs_identity();
+      if (_typeof(userVars) === 'object' && typeof userVars.uid === 'string') {
         fs('setUserVars')(userVars);
         fs('restart')();
       } else {

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -1,22 +1,6 @@
 (function () {
   'use strict';
 
-  function _typeof(obj) {
-    "@babel/helpers - typeof";
-
-    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-      _typeof = function (obj) {
-        return typeof obj;
-      };
-    } else {
-      _typeof = function (obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-      };
-    }
-
-    return _typeof(obj);
-  }
-
   function fs(api) {
     if (!hasFs()) {
       return function () {
@@ -59,7 +43,7 @@
   function identify() {
     if (typeof window._fs_identity === 'function') {
       var userVars = window._fs_identity();
-      if (_typeof(userVars) === 'object' && typeof userVars.uid === 'string') {
+      if (typeof userVars === 'object' && typeof userVars.uid === 'string') {
         fs('setUserVars')(userVars);
         fs('restart')();
       } else {

--- a/dist/medallia.js
+++ b/dist/medallia.js
@@ -4,13 +4,13 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error(`FullStory unavailable, check your snippet or tag`);
-      }
+        console.error("FullStory unavailable, check your snippet or tag");
+      };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
-        }
+          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+        };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
     }
@@ -20,19 +20,21 @@
   }
 
   function handleSubmitFeedback(event) {
-    const detail = event.detail;
+    var detail = event.detail;
     if (!detail) {
       fs('log')('warn', 'MDigital_Submit_Feedback data not found');
       return;
     }
-    const payload = {
+    var payload = {
       Form_Type: detail.Form_Type,
       Form_ID: detail.Form_ID,
-      Feedback_UUID: detail.Feedback_UUID,
+      Feedback_UUID: detail.Feedback_UUID
     };
-    for (let i = 0; i < detail.Content.length; i += 1) {
+    for (var i = 0; i < detail.Content.length; i += 1) {
       if (detail.Content[i].unique_name === 'NPS') {
-        fs('setUserVars')({ NPS: detail.Content[i].value });
+        fs('setUserVars')({
+          NPS: detail.Content[i].value
+        });
       } else {
         payload[detail.Content[i].unique_name] = detail.Content[i].value;
       }

--- a/dist/optimizely-page-vars.js
+++ b/dist/optimizely-page-vars.js
@@ -4,13 +4,13 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error(`FullStory unavailable, check your snippet or tag`);
-      }
+        console.error("FullStory unavailable, check your snippet or tag");
+      };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
-        }
+          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+        };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
     }
@@ -19,15 +19,30 @@
     return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
   }
 
+  function _typeof(obj) {
+    "@babel/helpers - typeof";
+
+    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+      _typeof = function (obj) {
+        return typeof obj;
+      };
+    } else {
+      _typeof = function (obj) {
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+      };
+    }
+
+    return _typeof(obj);
+  }
+
   function optimizely(api) {
     return api ? window.optimizely.get(api) : window.optimizely;
   }
   function getExperimentTuple(campaign, property, delimiter) {
-    return campaign.variation ? campaign.experiment[property].trim() + (delimiter || '=') + campaign.variation[property].trim() :
-      campaign.experiment[property].trim();
+    return campaign.variation ? campaign.experiment[property].trim() + (delimiter || '=') + campaign.variation[property].trim() : campaign.experiment[property].trim();
   }
   function campaignsToPageVars(campaignsObj) {
-    const campaignsList = campaignsToList(campaignsObj);
+    var campaignsList = campaignsToList(campaignsObj);
     return campaignsList.reduce(function (pageVars, campaign) {
       if (!campaign.isInCampaignHoldback) {
         pageVars.optimizely_experiment_names.push(getExperimentTuple(campaign, 'name'));
@@ -40,23 +55,25 @@
     });
   }
   function campaignsToList(campaignsObj) {
-    const list = [];
-    const props = Object.getOwnPropertyNames(campaignsObj);
-    for (let i = 0; i < props.length; i += 1) {
-      if (typeof campaignsObj[props[i]] === 'object') {
+    var list = [];
+    var props = Object.getOwnPropertyNames(campaignsObj);
+    for (var i = 0; i < props.length; i += 1) {
+      if (_typeof(campaignsObj[props[i]]) === 'object') {
         list.push(campaignsObj[props[i]]);
       }
     }
     return list;
   }
   function getActiveCampaigns() {
-    return optimizely('state').getCampaignStates({ isActive: true });
+    return optimizely('state').getCampaignStates({
+      isActive: true
+    });
   }
 
-  const utils = optimizely('utils');
+  var utils = optimizely('utils');
   utils.waitUntil(hasFs).then(function () {
-    const activeCampaigns = getActiveCampaigns();
-    const pageVars = campaignsToPageVars(activeCampaigns);
+    var activeCampaigns = getActiveCampaigns();
+    var pageVars = campaignsToPageVars(activeCampaigns);
     fs('setVars')('page', pageVars);
   });
 

--- a/dist/optimizely-page-vars.js
+++ b/dist/optimizely-page-vars.js
@@ -19,22 +19,6 @@
     return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
   }
 
-  function _typeof(obj) {
-    "@babel/helpers - typeof";
-
-    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-      _typeof = function (obj) {
-        return typeof obj;
-      };
-    } else {
-      _typeof = function (obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-      };
-    }
-
-    return _typeof(obj);
-  }
-
   function optimizely(api) {
     return api ? window.optimizely.get(api) : window.optimizely;
   }
@@ -58,7 +42,7 @@
     var list = [];
     var props = Object.getOwnPropertyNames(campaignsObj);
     for (var i = 0; i < props.length; i += 1) {
-      if (_typeof(campaignsObj[props[i]]) === 'object') {
+      if (typeof campaignsObj[props[i]] === 'object') {
         list.push(campaignsObj[props[i]]);
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,6 +1374,35 @@
         "chalk": "^4.0.0"
       }
     },
+    "@rollup/plugin-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1438,6 +1467,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
+    "@rollup/plugin-babel": "^5.3.0",
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
     "rollup": "^2.53.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import babel from '@rollup/plugin-babel';
 import cleanup from 'rollup-plugin-cleanup';
 import * as fs from 'fs';
 
@@ -9,7 +10,12 @@ const options = samples.map(filename => {
       file: __dirname + `/dist/${filename}`,
       format: 'iife'
     },
-    plugins: [cleanup()],
+    plugins: [
+      babel({
+        exclude: 'node_modules/**',
+        babelHelpers: 'bundled'
+      }),
+      cleanup()],
   };
 });
 


### PR DESCRIPTION
The PR adds `@babel/preset-env` `targets` to the build process.  To better ensure browser support relative to fs.js, I've added `targets` with versions listed on the [KB article](https://help.fullstory.com/hc/en-us/articles/360020624594-What-browsers-are-currently-supported-by-FullStory-#browsers-supported-by-fullstory-recording-snippet).  There's an `exclude` on `@babel/plugin-transform-typeof-symbol` because I just don't see where `typeof` needs to have a polyfill given the [browser versions](https://caniuse.com/mdn-javascript_operators_typeof) we target.

An interesting quirk is that interpolation can produce `console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));`.  The `concat`s are a little verbose so I'll go back and update the samples/helpers with arithmetic string concatenation.