### PR TITLE
Add dist to linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/dist/** linguist-generated=true


### PR DESCRIPTION
Hopefully a quick review ... I've added a [linguist-generated](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) indicator for the `/dist` folder per your recommendation a while back.  The goal is to remove `/dist` output from PR diffs since they don't need to be reviewed (only `src` needs review).