### PR TITLE
Option to use Medallia labels

### DIFF
--- a/__tests__/medallia.spec.js
+++ b/__tests__/medallia.spec.js
@@ -25,12 +25,20 @@ const MDigital_Submit_Feedback = {
       type: 'grading1to10',
       unique_name: 'OSAT_7_DIY_Home',
       value: 7
+    },
+    {
+      id: 422870,
+      type: 'grading1to10',
+      label: 'How would you rate your store visit?',
+      unique_name: 'OSAT_7_Store',
+      value: 5
     }
   ],
 };
 
 describe('Medallia Feedback', () => {
-  test('send feedback to FS.event and FS.setUserVars', () => {
+  test('send feedback to FS.event and FS.setUserVars using unique_name', () => {
+    // test sending the data as the default behavior (i.e. unique_name)
     // manually trigger feedback submission
     window.KAMPYLE_SDK.kampyleSubmit(MDigital_Submit_Feedback);
 
@@ -45,6 +53,49 @@ describe('Medallia Feedback', () => {
       Feedback_UUID: '1053-d865-ee90-1c9a-f81c-6965-c8ab-6b7d',
       Driver1_NPS: 6,
       OSAT_7_DIY_Home: 7,
+      OSAT_7_Store: 5,
+    });
+
+    // test sending the data by setting _fs_medallia_use_label false (i.e. unique_name)
+    window['_fs_medallia_use_label'] = false;
+
+    // manually trigger feedback submission
+    window.KAMPYLE_SDK.kampyleSubmit(MDigital_Submit_Feedback);
+
+    expect(fs('setUserVars')).toBeCalled();
+    expect(fs('setUserVars').mock.calls[0][0]).toEqual({ NPS: 9 });
+
+    expect(fs('event')).toBeCalled();
+    expect(fs('event').mock.calls[1][0]).toEqual('Medallia Feedback');
+    expect(fs('event').mock.calls[1][1]).toEqual({
+      Form_ID: '25266',
+      Form_Type: 'Intercept',
+      Feedback_UUID: '1053-d865-ee90-1c9a-f81c-6965-c8ab-6b7d',
+      Driver1_NPS: 6,
+      OSAT_7_DIY_Home: 7,
+      OSAT_7_Store: 5,
+    });
+  });
+
+  test('send feedback to FS.event and FS.setUserVars using label', () => {
+    // test sending the data by setting _fs_medallia_use_label true (i.e. label)
+    window['_fs_medallia_use_label'] = true;
+
+    // manually trigger feedback submission
+    window.KAMPYLE_SDK.kampyleSubmit(MDigital_Submit_Feedback);
+
+    expect(fs('setUserVars')).toBeCalled();
+    expect(fs('setUserVars').mock.calls[0][0]).toEqual({ NPS: 9 });
+
+    expect(fs('event')).toBeCalled();
+    expect(fs('event').mock.calls[2][0]).toEqual('Medallia Feedback');
+    expect(fs('event').mock.calls[2][1]).toEqual({
+      Form_ID: '25266',
+      Form_Type: 'Intercept',
+      Feedback_UUID: '1053-d865-ee90-1c9a-f81c-6965-c8ab-6b7d',
+      Driver1_NPS: 6,
+      OSAT_7_DIY_Home: 7, // NOTE there is no label so fall back to unique_name
+      'How_would_you_rate_your_store_visit?': 5, // NOTE FullStory will remove the ? char
     });
   });
 });

--- a/dist/fs-session-stitching.js
+++ b/dist/fs-session-stitching.js
@@ -4,12 +4,12 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error("FullStory unavailable, check your snippet or tag");
+        console.error('FullStory unavailable, check your snippet or tag');
       };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
         };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];

--- a/dist/google-optimize.js
+++ b/dist/google-optimize.js
@@ -4,12 +4,12 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error("FullStory unavailable, check your snippet or tag");
+        console.error('FullStory unavailable, check your snippet or tag');
       };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
         };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];

--- a/dist/medallia.js
+++ b/dist/medallia.js
@@ -4,12 +4,12 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error("FullStory unavailable, check your snippet or tag");
+        console.error('FullStory unavailable, check your snippet or tag');
       };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
         };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
@@ -45,7 +45,6 @@
     }
     fs('event')('Medallia Feedback', payload);
   }
-  window['_fs_medallia_use_label'] = false;
   if (!window['_fs_medallia_feedback_registered']) {
     window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
     window['_fs_medallia_feedback_registered'] = true;

--- a/dist/medallia.js
+++ b/dist/medallia.js
@@ -4,13 +4,13 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error(`FullStory unavailable, check your snippet or tag`);
-      }
+        console.error('FullStory unavailable, check your snippet or tag');
+      };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
-        }
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
+        };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
     }
@@ -20,25 +20,35 @@
   }
 
   function handleSubmitFeedback(event) {
-    const detail = event.detail;
+    var detail = event.detail;
     if (!detail) {
       fs('log')('warn', 'MDigital_Submit_Feedback data not found');
       return;
     }
-    const payload = {
+    var payload = {
       Form_Type: detail.Form_Type,
       Form_ID: detail.Form_ID,
-      Feedback_UUID: detail.Feedback_UUID,
+      Feedback_UUID: detail.Feedback_UUID
     };
-    for (let i = 0; i < detail.Content.length; i += 1) {
+    for (var i = 0; i < detail.Content.length; i += 1) {
       if (detail.Content[i].unique_name === 'NPS') {
-        fs('setUserVars')({ NPS: detail.Content[i].value });
+        fs('setUserVars')({
+          NPS: detail.Content[i].value
+        });
       } else {
-        payload[detail.Content[i].unique_name] = detail.Content[i].value;
+        if (window['_fs_medallia_use_label'] && detail.Content[i].label) {
+          payload[detail.Content[i].label.trim().replace(/\s/g, '_')] = detail.Content[i].value;
+        } else {
+          payload[detail.Content[i].unique_name] = detail.Content[i].value;
+        }
       }
     }
     fs('event')('Medallia Feedback', payload);
   }
-  window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
+  window['_fs_medallia_use_label'] = false;
+  if (!window['_fs_medallia_feedback_registered']) {
+    window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
+    window['_fs_medallia_feedback_registered'] = true;
+  }
 
 }());

--- a/dist/optimizely-page-vars.js
+++ b/dist/optimizely-page-vars.js
@@ -4,12 +4,12 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error("FullStory unavailable, check your snippet or tag");
+        console.error('FullStory unavailable, check your snippet or tag');
       };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
         };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];

--- a/dist/set-cookies.js
+++ b/dist/set-cookies.js
@@ -4,12 +4,12 @@
   function fs(api) {
     if (!hasFs()) {
       return function () {
-        console.error("FullStory unavailable, check your snippet or tag");
+        console.error('FullStory unavailable, check your snippet or tag');
       };
     } else {
       if (api && !window[window._fs_namespace][api]) {
         return function () {
-          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+          console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
         };
       }
       return api ? window[window._fs_namespace][api] : window[window._fs_namespace];

--- a/src/medallia.js
+++ b/src/medallia.js
@@ -3,7 +3,7 @@ import { fs } from './utils/fs';
 /**
  * Handles the MDigital_Submit_Feedback event:
  * - Attributes NPS score to user using `FS.setUserVars`
- * - Creates a single "Medallia Feedback" with content name value pairs
+ * - Creates a single "Medallia Feedback" custom event with content name value pairs
  * @param event MDigital_Submit_Feedback event
  */
 function handleSubmitFeedback(event) {
@@ -24,12 +24,25 @@ function handleSubmitFeedback(event) {
     if (detail.Content[i].unique_name === 'NPS') {
       fs('setUserVars')({ NPS: detail.Content[i].value });
     } else {
-      payload[detail.Content[i].unique_name] = detail.Content[i].value;
+      if (window['_fs_medallia_use_label'] && detail.Content[i].label) {
+        payload[detail.Content[i].label.trim().replace(/\s/g, '_')] = detail.Content[i].value;
+      } else {
+        payload[detail.Content[i].unique_name] = detail.Content[i].value;
+      }
     }
   }
 
   fs('event')('Medallia Feedback', payload);
 }
+
+/**
+ * window['_fs_medallia_use_label'] changes how feedback items are stored in the custom event.
+ * The default behavior is _fs_medallia_use_label=false.
+ * _fs_medallia_use_label=true stores "How would you rate our store?":7
+ * _fs_medallia_use_label=false stores OSAT_7_Store:7
+ */
+
+// window['_fs_medallia_use_label'] = true;
 
 if (!window['_fs_medallia_feedback_registered']) {
   window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);

--- a/src/medallia.js
+++ b/src/medallia.js
@@ -38,7 +38,7 @@ function handleSubmitFeedback(event) {
 /**
  * window['_fs_medallia_use_label'] changes how feedback items are stored in the custom event.
  * The default behavior is _fs_medallia_use_label=false.
- * _fs_medallia_use_label=true stores "How would you rate our store?":7
+ * _fs_medallia_use_label=true stores "How_would_you_rate_our_store":7
  * _fs_medallia_use_label=false stores OSAT_7_Store:7
  */
 

--- a/src/medallia.js
+++ b/src/medallia.js
@@ -31,4 +31,7 @@ function handleSubmitFeedback(event) {
   fs('event')('Medallia Feedback', payload);
 }
 
-window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
+if (!window['_fs_medallia_feedback_registered']) {
+  window.addEventListener('MDigital_Submit_Feedback', handleSubmitFeedback);
+  window['_fs_medallia_feedback_registered'] = true;
+}

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -6,13 +6,13 @@
 export function fs(api) {
   if (!hasFs()) {
     return function () {
-      console.error(`FullStory unavailable, check your snippet or tag`);
+      console.error('FullStory unavailable, check your snippet or tag');
     }
   } else {
     // guard against older snippets that may not define an API
     if (api && !window[window._fs_namespace][api]) {
       return function () {
-        console.error(`${window._fs_namespace}.${api} unavailable, update your snippet or verify the API call`);
+        console.error(window._fs_namespace + '.' + api + ' unavailable, update your snippet or verify the API call');
       }
     }
     return api ? window[window._fs_namespace][api] : window[window._fs_namespace];


### PR DESCRIPTION
This PR adds an option to control the Medallia integration.  It's possible that the feedback object returned by Medallia contains the question's label.  This is more readable that the question ID that the default implementation provides.  Usage and details are in the comment within code:

```
/**
 * window['_fs_medallia_use_label'] changes how feedback items are stored in the custom event.
 * The default behavior is _fs_medallia_use_label=false.
 * _fs_medallia_use_label=true stores "How_would_you_rate_our_store":7
 * _fs_medallia_use_label=false stores OSAT_7_Store:7
 */
```

I also had a change that removes the string interpolation in TS code since it transpiled to `"".contact(<some string>)`, which was a little odd to see.  The code in `src/utils/fs.js` simply uses arithmetic `+` to concat strings.

FYI @visa-fs 