### PR TITLE
Google optimize throttle (and making fs_ready able to handle multiple…

### DIFF
--- a/__mocks__/dataLayer.js
+++ b/__mocks__/dataLayer.js
@@ -5,6 +5,8 @@
 // used for GOOGLE OPTIMIZE implementation
 export const OPTIMIZE_ID = "123456";
 export const VARIANT = "1";
+export const OPTIMIZE_ID2 = "1234567";
+export const VARIANT2 = "2";
 
 let dataLayer = {};
 // implement the push function.  New implementations can be placed in here
@@ -20,6 +22,13 @@ dataLayer.push = jest.fn( (newValue) => {
   // look for very specific event, optimize.callback, callbackfn() push
   if( operation && (operation === "event") && description && (description === "optimize.callback") && object && (typeof( object.callback ) === "function") ){
     object.callback( VARIANT, OPTIMIZE_ID );
+    object.callback( VARIANT, OPTIMIZE_ID2 );
+    object.callback( VARIANT, OPTIMIZE_ID );
+    // this one should be filtered out
+    object.callback( VARIANT, OPTIMIZE_ID );
+    object.callback( VARIANT2, OPTIMIZE_ID );
+    // as should the following one
+    object.callback( VARIANT2, OPTIMIZE_ID );
   }
 });
 Object.defineProperty(window, 'dataLayer', {

--- a/__mocks__/dataLayer.js
+++ b/__mocks__/dataLayer.js
@@ -8,6 +8,7 @@ export const VARIANT = "1";
 export const OPTIMIZE_ID2 = "1234567";
 export const VARIANT2 = "2";
 
+
 let dataLayer = {};
 // implement the push function.  New implementations can be placed in here
 dataLayer.push = jest.fn( (newValue) => {
@@ -29,6 +30,14 @@ dataLayer.push = jest.fn( (newValue) => {
     object.callback( VARIANT2, OPTIMIZE_ID );
     // as should the following one
     object.callback( VARIANT2, OPTIMIZE_ID );
+    // this one depends on wait setting
+    setTimeout( () => {
+      object.callback( VARIANT2, OPTIMIZE_ID );
+    }, 500 );
+    // as does this one
+    setTimeout( () => {
+      object.callback( VARIANT2, OPTIMIZE_ID );
+    }, 1100 );
   }
 });
 Object.defineProperty(window, 'dataLayer', {

--- a/__tests__/google-optimize-spec.js
+++ b/__tests__/google-optimize-spec.js
@@ -1,5 +1,5 @@
 import '../__mocks__/fs';
-import {OPTIMIZE_ID, VARIANT} from "../__mocks__/dataLayer";
+import {OPTIMIZE_ID, OPTIMIZE_ID2, VARIANT, VARIANT2} from "../__mocks__/dataLayer";
 import { fs } from '../src/utils/fs';
 import '../src/google-optimize';
 import {makeFSReady} from "../__mocks__/fs";
@@ -9,11 +9,26 @@ describe('Google Optimize', () => {
     makeFSReady();
     window._fs_ready();
     // manually trigger feedback submission
-    expect(fs('event')).toBeCalled();
+    expect(fs('event')).toBeCalledTimes(4);
     expect(fs('event').mock.calls[0][0]).toEqual('Experiment Viewed');
     expect(fs('event').mock.calls[0][1]).toEqual({
       experiment_id: OPTIMIZE_ID,
       experiment_value: VARIANT
+    });
+    expect(fs('event').mock.calls[1][0]).toEqual('Experiment Viewed');
+    expect(fs('event').mock.calls[1][1]).toEqual({
+      experiment_id: OPTIMIZE_ID2,
+      experiment_value: VARIANT
+    });
+    expect(fs('event').mock.calls[2][0]).toEqual('Experiment Viewed');
+    expect(fs('event').mock.calls[2][1]).toEqual({
+      experiment_id: OPTIMIZE_ID,
+      experiment_value: VARIANT
+    });
+    expect(fs('event').mock.calls[3][0]).toEqual('Experiment Viewed');
+    expect(fs('event').mock.calls[3][1]).toEqual({
+      experiment_id: OPTIMIZE_ID,
+      experiment_value: VARIANT2
     });
   });
 });

--- a/__tests__/google-optimize-spec.js
+++ b/__tests__/google-optimize-spec.js
@@ -5,30 +5,55 @@ import '../src/google-optimize';
 import {makeFSReady} from "../__mocks__/fs";
 
 describe('Google Optimize', () => {
-  test('send FS.event from dataLayer callback', () => {
+  test('send FS.event from dataLayer callback', (done) => {
     makeFSReady();
     window._fs_ready();
-    // manually trigger feedback submission
-    expect(fs('event')).toBeCalledTimes(4);
-    expect(fs('event').mock.calls[0][0]).toEqual('Experiment Viewed');
-    expect(fs('event').mock.calls[0][1]).toEqual({
-      experiment_id: OPTIMIZE_ID,
-      experiment_value: VARIANT
-    });
-    expect(fs('event').mock.calls[1][0]).toEqual('Experiment Viewed');
-    expect(fs('event').mock.calls[1][1]).toEqual({
-      experiment_id: OPTIMIZE_ID2,
-      experiment_value: VARIANT
-    });
-    expect(fs('event').mock.calls[2][0]).toEqual('Experiment Viewed');
-    expect(fs('event').mock.calls[2][1]).toEqual({
-      experiment_id: OPTIMIZE_ID,
-      experiment_value: VARIANT
-    });
-    expect(fs('event').mock.calls[3][0]).toEqual('Experiment Viewed');
-    expect(fs('event').mock.calls[3][1]).toEqual({
-      experiment_id: OPTIMIZE_ID,
-      experiment_value: VARIANT2
+    testOptimizeWithWait( () => {
+      expect(fs('event')).toBeCalledTimes(5);
+      expect(fs('event').mock.calls[0][0]).toEqual('Experiment Viewed');
+      expect(fs('event').mock.calls[0][1]).toEqual({
+        experiment_id: OPTIMIZE_ID,
+        experiment_value: VARIANT
+      });
+      expect(fs('event').mock.calls[1][0]).toEqual('Experiment Viewed');
+      expect(fs('event').mock.calls[1][1]).toEqual({
+        experiment_id: OPTIMIZE_ID2,
+        experiment_value: VARIANT
+      });
+      expect(fs('event').mock.calls[2][0]).toEqual('Experiment Viewed');
+      expect(fs('event').mock.calls[2][1]).toEqual({
+        experiment_id: OPTIMIZE_ID,
+        experiment_value: VARIANT
+      });
+      expect(fs('event').mock.calls[3][0]).toEqual('Experiment Viewed');
+      expect(fs('event').mock.calls[3][1]).toEqual({
+        experiment_id: OPTIMIZE_ID,
+        experiment_value: VARIANT2
+      });
+      expect(fs('event').mock.calls[3][0]).toEqual('Experiment Viewed');
+      expect(fs('event').mock.calls[3][1]).toEqual({
+        experiment_id: OPTIMIZE_ID,
+        experiment_value: VARIANT2
+      });
+      done();
     });
   });
+
+  test('send FS.event from dataLayer callback', (done) => {
+    window['_fs_google_optimize_throttle' ] = 300;
+    window._fs_ready();
+    testOptimizeWithWait( () => {
+      // please note this will be the times above plus the times this test should run
+      expect(fs('event')).toBeCalledTimes(11);
+      done();
+    });
+  });
+
+
+  // dataLayer adds up to around 2 seconds
+  function testOptimizeWithWait( callbackFn ){
+    setTimeout( () => {
+      callbackFn();
+    }, 2000 );
+  }
 });

--- a/dist/adobe-target.js
+++ b/dist/adobe-target.js
@@ -46,7 +46,8 @@
       },
       set: function set(someFunction) {
         _fsReadyFunctions.push(someFunction);
-      }
+      },
+      configurable: true
     });
   }
 

--- a/dist/google-optimize.js
+++ b/dist/google-optimize.js
@@ -46,7 +46,8 @@
       },
       set: function set(someFunction) {
         _fsReadyFunctions.push(someFunction);
-      }
+      },
+      configurable: true
     });
   }
 
@@ -59,9 +60,21 @@
       callback: optimizeCallback
     });
   });
-  function optimizeCallback(value, name) {
+  var lastExperimentID = undefined;
+  var lastExperimentValue = undefined;
+  var lastExperimentFired = undefined;
+  function optimizeCallback(value, id) {
+    var now = Date.now();
+    if (lastExperimentID === id && lastExperimentValue === value) {
+      if (lastExperimentFired && now - lastExperimentFired < 1000) {
+        return;
+      }
+    }
+    lastExperimentFired = now;
+    lastExperimentID = id;
+    lastExperimentValue = value;
     fs("event")("Experiment Viewed", {
-      experiment_id: name,
+      experiment_id: id,
       experiment_value: value
     });
   }

--- a/dist/google-optimize.js
+++ b/dist/google-optimize.js
@@ -64,9 +64,11 @@
   var lastExperimentValue = undefined;
   var lastExperimentFired = undefined;
   function optimizeCallback(value, id) {
+    var testThrottleValue = parseInt(window['_fs_google_optimize_throttle']);
+    var throttleValue = Number.isNaN(testThrottleValue) ? 1000 : testThrottleValue;
     var now = Date.now();
     if (lastExperimentID === id && lastExperimentValue === value) {
-      if (lastExperimentFired && now - lastExperimentFired < 1000) {
+      if (lastExperimentFired && now - lastExperimentFired < throttleValue) {
         return;
       }
     }

--- a/dist/set-cookies.js
+++ b/dist/set-cookies.js
@@ -46,7 +46,8 @@
       },
       set: function set(someFunction) {
         _fsReadyFunctions.push(someFunction);
-      }
+      },
+      configurable: true
     });
   }
 

--- a/src/google-optimize.js
+++ b/src/google-optimize.js
@@ -15,12 +15,25 @@ registerFsReady(
     })
   });
 
+let lastExperimentID = undefined;
+let lastExperimentValue = undefined;
+let lastExperimentFired = undefined;
+
 // take the optimize callback and turn it into an FS event
-function optimizeCallback( value, name ) {
+function optimizeCallback( value, id ) {
   // "Experiment Viewed" was selected as of the time of this addition, it allows for a higher
-  // rate limit on calls.  Instead of 10/second 30/minute default, it allows 40/second 60/minute
+  // rate limit on calls.  Instead of 10/second 30/minute default, it allows 40/second 60/minut
+  let now = Date.now();
+  if( (lastExperimentID === id) && (lastExperimentValue === value) ){
+    if( lastExperimentFired && (now - lastExperimentFired < 1000) ){
+      return;
+    }
+  }
+  lastExperimentFired = now;
+  lastExperimentID = id;
+  lastExperimentValue = value;
   fs( "event" )( "Experiment Viewed", {
-    experiment_id: name,
+    experiment_id: id,
     experiment_value: value
   });
 }

--- a/src/google-optimize.js
+++ b/src/google-optimize.js
@@ -18,14 +18,15 @@ registerFsReady(
 let lastExperimentID = undefined;
 let lastExperimentValue = undefined;
 let lastExperimentFired = undefined;
-
 // take the optimize callback and turn it into an FS event
 function optimizeCallback( value, id ) {
+  let testThrottleValue = parseInt( window['_fs_google_optimize_throttle'] );
+  let throttleValue = Number.isNaN( testThrottleValue ) ? 1000 : testThrottleValue;
   // "Experiment Viewed" was selected as of the time of this addition, it allows for a higher
   // rate limit on calls.  Instead of 10/second 30/minute default, it allows 40/second 60/minut
   let now = Date.now();
   if( (lastExperimentID === id) && (lastExperimentValue === value) ){
-    if( lastExperimentFired && (now - lastExperimentFired < 1000) ){
+    if( lastExperimentFired && (now - lastExperimentFired < throttleValue) ){
       return;
     }
   }

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -147,6 +147,7 @@ export function registerFsReady( callbackFn ) {
     },
     set( someFunction ) {
       _fsReadyFunctions.push( someFunction );
-    }
+    },
+    configurable: true
   });
 }


### PR DESCRIPTION
Makes google optimize integration only fire the same value at most once per second.  Some sites use "continuous" and it can cause rate limiting.  This also fixes a problem where fs_ready was not configurable, meaning if you used multiple integration examples separately, they would not work.  Found this with GNC and just hand't committed it yet.  