### PR TITLE
Keypress listener

### DIFF
--- a/__tests__/keypress.spec.js
+++ b/__tests__/keypress.spec.js
@@ -2,30 +2,31 @@ import '../__mocks__/fs';
 import { fs } from '../src/utils/fs';
 import '../src/keypress';
 
-// NOTE by default the integration listens for tab key events
-
-describe('Keydown Page Vars', () => {
-  test('record a keydown event as a page var', () => {
+describe('Keydown Custom Event', () => {
+  test('record a keydown custom event', () => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 
-    expect(fs('setVars')).toBeCalled();
-    expect(fs('setVars').mock.calls[0][0]).toEqual('page');
-    expect(fs('setVars').mock.calls[0][1]).toEqual({ key_tab_count_int: 1 });
+    expect(fs('event')).toBeCalled();
+    expect(fs('event').mock.calls[0][0]).toEqual('Key Pressed');
+    expect(fs('event').mock.calls[0][1]).toEqual({ key: 'Tab' });
   });
 
-  test('ignored keys are not recorded as page vars', () => {
+  test('ignored keys are not recorded', () => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
 
-    expect(fs('setVars')).toBeCalledTimes(1);
+    expect(fs('event')).toBeCalledTimes(1);
   });
 
-  test('subsequent keydown events increment the page var', () => {
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+  test('arrow keys and the tab key are recorded by default', () => {
+    const defaultKeys = ['Tab', 'ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'];
 
-    expect(fs('setVars')).toBeCalledTimes(2);
+    for (let i = 0; i < defaultKeys.length; i += 1) {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: defaultKeys[i] }));
 
-    expect(fs('setVars').mock.calls[1][0]).toEqual('page');
-    expect(fs('setVars').mock.calls[1][1]).toEqual({ key_tab_count_int: 2 });
+      expect(fs('event')).toBeCalledTimes(i + 2);
+      expect(fs('event').mock.calls[i + 1][0]).toEqual('Key Pressed');
+      expect(fs('event').mock.calls[i + 1][1]).toEqual({ key: defaultKeys[i] });
+    }
   });
 });

--- a/__tests__/keypress.spec.js
+++ b/__tests__/keypress.spec.js
@@ -1,0 +1,31 @@
+import '../__mocks__/fs';
+import { fs } from '../src/utils/fs';
+import '../src/keypress';
+
+// NOTE by default the integration listens for tab key events
+
+describe('Keydown Page Vars', () => {
+  test('record a keydown event as a page var', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+
+    expect(fs('setVars')).toBeCalled();
+    expect(fs('setVars').mock.calls[0][0]).toEqual('page');
+    expect(fs('setVars').mock.calls[0][1]).toEqual({ key_tab_count_int: 1 });
+  });
+
+  test('ignored keys are not recorded as page vars', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+
+    expect(fs('setVars')).toBeCalledTimes(1);
+  });
+
+  test('subsequent keydown events increment the page var', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+
+    expect(fs('setVars')).toBeCalledTimes(2);
+
+    expect(fs('setVars').mock.calls[1][0]).toEqual('page');
+    expect(fs('setVars').mock.calls[1][1]).toEqual({ key_tab_count_int: 2 });
+  });
+});

--- a/dist/keypress.js
+++ b/dist/keypress.js
@@ -1,0 +1,42 @@
+(function () {
+  'use strict';
+
+  function fs(api) {
+    if (!hasFs()) {
+      return function () {
+        console.error("FullStory unavailable, check your snippet or tag");
+      };
+    } else {
+      if (api && !window[window._fs_namespace][api]) {
+        return function () {
+          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+        };
+      }
+      return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
+    }
+  }
+  function hasFs() {
+    return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
+  }
+
+  var keys = !window['_fs_integration_keys'] || window['_fs_integration_keys'].length === 0 ? ['tab'] : window['_fs_integration_keys'].map(function (key) {
+    return key.toLowerCase();
+  });
+  var keyCount = {};
+  function handleKeydown(event) {
+    var key = event.key;
+    var lowercaseKey = key.toLowerCase();
+    if (keys.indexOf(lowercaseKey) > -1) {
+      keyCount[lowercaseKey] = keyCount[lowercaseKey] === undefined ? 1 : keyCount[lowercaseKey] + 1;
+      var payload = {};
+      payload["key_".concat(lowercaseKey, "_count_int")] = keyCount[lowercaseKey];
+      fs('setVars')('page', payload);
+    }
+  }
+  if (keys && keys.length > 0) {
+    document.addEventListener('keydown', handleKeydown);
+  } else {
+    fs('log')('_fs_integration_keys is not configured');
+  }
+
+}());

--- a/dist/keypress.js
+++ b/dist/keypress.js
@@ -19,24 +19,20 @@
     return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
   }
 
-  var keys = !window['_fs_integration_keys'] || window['_fs_integration_keys'].length === 0 ? ['tab'] : window['_fs_integration_keys'].map(function (key) {
-    return key.toLowerCase();
-  });
-  var keyCount = {};
-  function handleKeydown(event) {
+  var defaultKeys = ['Tab', 'ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'];
+  var keys = window['_fs_allowed_keys'] || defaultKeys;
+  function handleKeyup(event) {
     var key = event.key;
-    var lowercaseKey = key.toLowerCase();
-    if (keys.indexOf(lowercaseKey) > -1) {
-      keyCount[lowercaseKey] = keyCount[lowercaseKey] === undefined ? 1 : keyCount[lowercaseKey] + 1;
-      var payload = {};
-      payload["key_".concat(lowercaseKey, "_count_int")] = keyCount[lowercaseKey];
-      fs('setVars')('page', payload);
+    if (keys.indexOf(key) > -1) {
+      fs('event')('Key Pressed', {
+        key: key
+      });
     }
   }
   if (keys && keys.length > 0) {
-    document.addEventListener('keydown', handleKeydown);
+    document.addEventListener('keyup', handleKeyup);
   } else {
-    fs('log')('_fs_integration_keys is not configured');
+    fs('log')('_fs_allowed_keys is not configured');
   }
 
 }());

--- a/src/keypress.js
+++ b/src/keypress.js
@@ -1,0 +1,35 @@
+import { fs } from './utils/fs';
+
+// a list of keys (e.g. 'a' or 'Tab'); the value should match a keyboard event's `key` property
+// keys should significant and pressed infrequently as to prevent rate limiting by FullStory
+// window['_fs_integration_keys'] = ['tab']
+
+// convert the keys to lower case to support the user being able to specify 'tab' or 'Tab'
+const keys = !window['_fs_integration_keys'] || window['_fs_integration_keys'].length === 0 ? ['tab'] : window['_fs_integration_keys'].map(key => key.toLowerCase());
+
+// a dictionary of key:count pairs
+const keyCount = {};
+
+function handleKeydown(event) {
+  const { key } = event;
+  const lowercaseKey = key.toLowerCase();
+
+  // verify that the key should be recorded as a page var
+  if (keys.indexOf(lowercaseKey) > -1) {
+    keyCount[lowercaseKey] = keyCount[lowercaseKey] === undefined ? 1 : keyCount[lowercaseKey] + 1;
+
+    // set the page var to key_<key>_count_int (e.g. key_tab_count_int=3)
+    const payload = {};
+    payload[`key_${lowercaseKey}_count_int`] = keyCount[lowercaseKey];
+
+    // update the page var
+    fs('setVars')('page', payload);
+  }
+}
+
+// if there are no keys of interest, skip registering an event listener
+if (keys && keys.length > 0) {
+  document.addEventListener('keydown', handleKeydown);
+} else {
+  fs('log')('_fs_integration_keys is not configured');
+}

--- a/src/keypress.js
+++ b/src/keypress.js
@@ -16,7 +16,7 @@ const keys = window['_fs_allowed_keys'] || defaultKeys;
 function handleKeyup(event) {
   const { key } = event;
 
-  // verify that the key should be recorded as a page var
+  // verify that the key should be recorded
   if (keys.indexOf(key) > -1) {
     fs('event')('Key Pressed', {
       key,

--- a/src/keypress.js
+++ b/src/keypress.js
@@ -13,7 +13,7 @@ const keys = window['_fs_allowed_keys'] || defaultKeys;
  * use cases related to page navigation.
  * @param event KeyBoard event
  */
-function handleKeydown(event) {
+function handleKeyup(event) {
   const { key } = event;
 
   // verify that the key should be recorded as a page var
@@ -26,7 +26,8 @@ function handleKeydown(event) {
 
 // if there are no keys of interest, skip registering an event listener
 if (keys && keys.length > 0) {
-  document.addEventListener('keydown', handleKeydown);
+  // use keyup since holding down a key will fire multiple events and cause rate limiting
+  document.addEventListener('keyup', handleKeyup);
 } else {
   fs('log')('_fs_allowed_keys is not configured');
 }

--- a/src/keypress.js
+++ b/src/keypress.js
@@ -1,29 +1,26 @@
 import { fs } from './utils/fs';
 
-// a list of keys (e.g. 'a' or 'Tab'); the value should match a keyboard event's `key` property
+const defaultKeys = ['Tab', 'ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'];
+
+// a list of keys (e.g. "Tab"); values should match a keyboard event's "key" property
 // keys should significant and pressed infrequently as to prevent rate limiting by FullStory
-// window['_fs_integration_keys'] = ['tab']
+// window['_fs_allowed_keys'] = ['tab'];
+const keys = window['_fs_allowed_keys'] || defaultKeys;
 
-// convert the keys to lower case to support the user being able to specify 'tab' or 'Tab'
-const keys = !window['_fs_integration_keys'] || window['_fs_integration_keys'].length === 0 ? ['tab'] : window['_fs_integration_keys'].map(key => key.toLowerCase());
-
-// a dictionary of key:count pairs
-const keyCount = {};
-
+/**
+ * Creates a "Key Pressed" custom event with the property "key" set to the key pressed by the user.
+ * This approach should be used for infrequent, significant key events such as the tab key or arrow keys that support
+ * use cases related to page navigation.
+ * @param event KeyBoard event
+ */
 function handleKeydown(event) {
   const { key } = event;
-  const lowercaseKey = key.toLowerCase();
 
   // verify that the key should be recorded as a page var
-  if (keys.indexOf(lowercaseKey) > -1) {
-    keyCount[lowercaseKey] = keyCount[lowercaseKey] === undefined ? 1 : keyCount[lowercaseKey] + 1;
-
-    // set the page var to key_<key>_count_int (e.g. key_tab_count_int=3)
-    const payload = {};
-    payload[`key_${lowercaseKey}_count_int`] = keyCount[lowercaseKey];
-
-    // update the page var
-    fs('setVars')('page', payload);
+  if (keys.indexOf(key) > -1) {
+    fs('event')('Key Pressed', {
+      key,
+    });
   }
 }
 
@@ -31,5 +28,5 @@ function handleKeydown(event) {
 if (keys && keys.length > 0) {
   document.addEventListener('keydown', handleKeydown);
 } else {
-  fs('log')('_fs_integration_keys is not configured');
+  fs('log')('_fs_allowed_keys is not configured');
 }


### PR DESCRIPTION
This is a basic sample of logging allow-listed key presses.  We used this to investigate alternative ways to navigate a website (i.e. using the keyboard instead of a mouse).