### PR TITLE
Swipe listener

### DIFF
--- a/dist/swipe.js
+++ b/dist/swipe.js
@@ -65,7 +65,7 @@
       elements[i].addEventListener('touchend', handleTouchend);
     }
   } else {
-    fs('_fs_swipe_selector is not configured');
+    fs('log')('_fs_swipe_selector is not configured');
   }
 
 }());

--- a/dist/swipe.js
+++ b/dist/swipe.js
@@ -1,0 +1,71 @@
+(function () {
+  'use strict';
+
+  function fs(api) {
+    if (!hasFs()) {
+      return function () {
+        console.error("FullStory unavailable, check your snippet or tag");
+      };
+    } else {
+      if (api && !window[window._fs_namespace][api]) {
+        return function () {
+          console.error("".concat(window._fs_namespace, ".").concat(api, " unavailable, update your snippet or verify the API call"));
+        };
+      }
+      return api ? window[window._fs_namespace][api] : window[window._fs_namespace];
+    }
+  }
+  function hasFs() {
+    return window._fs_namespace && typeof window[window._fs_namespace] === 'function';
+  }
+
+  var verticalThreshold = 50;
+  var leftSwipeCount = 0;
+  var rightSwipeCount = 0;
+  var xStart = null;
+  var yStart = null;
+  function handleTouchstart(event) {
+    var touch = event.changedTouches[0];
+    if (touch) {
+      xStart = touch.clientX;
+      yStart = touch.clientY;
+    } else {
+      xStart = null;
+      yStart = null;
+    }
+  }
+  function handleTouchend(event) {
+    if (!xStart || !yStart) {
+      return;
+    }
+    var touch = event.changedTouches[0];
+    if (touch) {
+      var xEnd = touch.clientX;
+      var yEnd = touch.clientY;
+      if (Math.abs(yEnd - yStart) <= verticalThreshold) {
+        if (xEnd - xStart < 0) {
+          leftSwipeCount++;
+        } else {
+          rightSwipeCount++;
+        }
+        fs('setVars')('page', {
+          swipe_left_count_int: leftSwipeCount,
+          swipe_right_count_int: rightSwipeCount
+        });
+      }
+    }
+    xStart = null;
+    yStart = null;
+  }
+  var selector = window['_fs_swipe_selector'] || 'body';
+  var elements = document.querySelectorAll(selector);
+  if (elements.length > 0) {
+    for (var i = 0; i < elements.length; i += 1) {
+      elements[i].addEventListener('touchstart', handleTouchstart);
+      elements[i].addEventListener('touchend', handleTouchend);
+    }
+  } else {
+    fs('_fs_swipe_selector is not configured');
+  }
+
+}());

--- a/src/swipe.js
+++ b/src/swipe.js
@@ -1,0 +1,76 @@
+import { fs } from './utils/fs';
+
+// the Y coordinate's pixel distance that denotes a vertical swipe event
+const verticalThreshold = 50;
+
+let leftSwipeCount = 0;
+let rightSwipeCount = 0;
+
+let xStart = null;
+let yStart = null;
+
+/**
+ * Stores X,Y coordinates when the user first touches within a mobile browser.
+ * @param event The touchstart TouchEvent
+ */
+function handleTouchstart(event) {
+  const touch = event.changedTouches[0];
+
+  if (touch) {
+    xStart = touch.clientX;
+    yStart = touch.clientY;
+  } else {
+    xStart = null;
+    yStart = null;
+  }
+};
+
+/**
+ * Creates "swipe_left_count" and "swipe_right_count" page variables indication the number of times the user
+ * swipes left or right within a mobile browser.
+ * @param event The touchend TouchEvent
+ */
+function handleTouchend(event) {
+  if (!xStart || !yStart) {
+    return;
+  }
+
+  const touch = event.changedTouches[0];
+
+  if (touch) {
+    const xEnd = touch.clientX;
+    const yEnd = touch.clientY;
+
+    // ignore vertical swipes, which could simply occur as the user scrolls the page
+    if (Math.abs(yEnd - yStart) <= verticalThreshold) {
+      if (xEnd - xStart < 0) {
+        leftSwipeCount++;
+      } else {
+        rightSwipeCount++;
+      }
+
+      fs('setVars')('page', {
+        swipe_left_count_int: leftSwipeCount,
+        swipe_right_count_int: rightSwipeCount,
+      });
+    }
+  }
+
+  xStart = null;
+  yStart = null;
+};
+
+// ideally, provide a CSS selector to target specific elements for swipe events
+// window['_fs_swipe_selector'] = '.slider';
+const selector = window['_fs_swipe_selector'] || 'body';
+
+const elements = document.querySelectorAll(selector);
+
+if (elements.length > 0) {
+  for (let i = 0; i < elements.length; i += 1) {
+    elements[i].addEventListener('touchstart', handleTouchstart);
+    elements[i].addEventListener('touchend', handleTouchend);
+  }
+} else {
+  fs('_fs_swipe_selector is not configured');
+}

--- a/src/swipe.js
+++ b/src/swipe.js
@@ -72,5 +72,5 @@ if (elements.length > 0) {
     elements[i].addEventListener('touchend', handleTouchend);
   }
 } else {
-  fs('_fs_swipe_selector is not configured');
+  fs('log')('_fs_swipe_selector is not configured');
 }


### PR DESCRIPTION
This examples creates "swipe_left_count" and "swipe_right_count" page variables indicating the number of times the user swipes left or right within a mobile browser.  This is useful because while clicks on an item in a carousel is automatically captured, swipe events are not.  Thus to understand browsing behavior within a carousel, a swipe listener is needed.