### PR TITLE
Sampling using localStorage

### DIFF
--- a/dist/sample-cookie.js
+++ b/dist/sample-cookie.js
@@ -1,0 +1,30 @@
+(function () {
+  'use strict';
+
+  function sampleCookie() {
+    var rate = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 10;
+    var days = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 30;
+    var cookieName = '_fs_sample_user';
+    try {
+      if (document.cookie.indexOf(cookieName + '=true') > -1 || document.cookie.indexOf(cookieName + '=false') > -1) {
+        return document.cookie.indexOf(cookieName + '=true') > -1;
+      } else {
+        var shouldSample = Math.random() < rate / 100;
+        var date = new Date();
+        date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+        document.cookie = cookieName + '=' + shouldSample + '; expires=' + date.toGMTString() + '; path=/';
+        return shouldSample;
+      }
+    } catch (err) {
+      console.error('FullStory not loaded, unable to sample user');
+      return false;
+    }
+  }
+
+  var rate = 10;
+  var days = 90;
+  if (sampleCookie(rate, days)) {
+    console.log('REPLACE THIS ENTIRE LINE AND CONSOLE LOG WITH YOUR FULLSTORY SNIPPET');
+  }
+
+}());

--- a/dist/sample-local-storage.js
+++ b/dist/sample-local-storage.js
@@ -1,0 +1,33 @@
+(function () {
+  'use strict';
+
+  function sampleLocalStorage() {
+    var rate = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 10;
+    var days = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 30;
+    var key = '_fs_sample_user';
+    try {
+      var now = new Date();
+      var value = JSON.parse(localStorage.getItem(key));
+      if (value !== null && now.getTime() <= value.expires) {
+        return value.sample;
+      } else {
+        var shouldSample = Math.random() < rate / 100;
+        localStorage.setItem(key, JSON.stringify({
+          sample: shouldSample,
+          expires: now.getTime() + days * 24 * 60 * 60 * 1000
+        }));
+        return shouldSample;
+      }
+    } catch (err) {
+      console.error('FullStory not loaded, unable to sample user');
+      return false;
+    }
+  }
+
+  var rate = 10;
+  var days = 90;
+  if (sampleLocalStorage(rate, days)) {
+    console.log('REPLACE THIS ENTIRE LINE AND CONSOLE LOG WITH YOUR FULLSTORY SNIPPET');
+  }
+
+}());

--- a/src/sample-cookie.js
+++ b/src/sample-cookie.js
@@ -1,11 +1,11 @@
-import { sample } from './utils/fs';
+import { sampleCookie } from './utils/fs';
 
 // sample 10% of users (i.e. 1 out of every 10 users)
 const rate = 10;
 
 // re-sample the user after 90 days have elapsed (i.e. cookie expiration)
-const daysValid = 90;
+const days = 90;
 
-if (sample(rate, daysValid)) {
+if (sampleCookie(rate, days)) {
   console.log('REPLACE THIS ENTIRE LINE AND CONSOLE LOG WITH YOUR FULLSTORY SNIPPET');
 }

--- a/src/sample-local-storage.js
+++ b/src/sample-local-storage.js
@@ -1,0 +1,11 @@
+import { sampleLocalStorage } from './utils/fs';
+
+// sample 10% of users (i.e. 1 out of every 10 users)
+const rate = 10;
+
+// re-sample the user after 90 days have elapsed
+const days = 90;
+
+if (sampleLocalStorage(rate, days)) {
+  console.log('REPLACE THIS ENTIRE LINE AND CONSOLE LOG WITH YOUR FULLSTORY SNIPPET');
+}


### PR DESCRIPTION
This PR focuses on using an alternative to cookie-based sampling and uses `localStorage`.  The existing sampling code was moved into `sampleCookie`.  A new `sampleLocalStorage` was implemented to use `localStorage` for persistence and also support expiration.  This `sampleCookie` and `sampleLocalStorage` have the same function signature.  The `sample` function then allows the user to decide which sampling storage strategy to use.

The `dist` files use the respective `sampleCookie` or `sampleLocalStorage` as to limit the size of the sampling example.